### PR TITLE
feat: add task edit/update functionality with real-time sync (NSOC'26)

### DIFF
--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -41,7 +41,7 @@ export const createTask = async (req, res) => {
   }
 };
 
-// Update task status and position
+//update task status
 export const updateTaskStatus = async (req, res) => {
   try {
     const { id } = req.params;
@@ -56,6 +56,59 @@ export const updateTaskStatus = async (req, res) => {
     if (error) throw error;
 
     res.status(200).json(data[0]);
+  } catch (error) {
+    console.error("Error updating task status:", error);
+    res.status(500).json({ error: "Failed to update task status" });
+  }
+};
+
+export const updateTask = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { title, description, status } = req.body;
+    const updateFields = {};
+
+    if (title !== undefined) updateFields.title = title;
+    if (description !== undefined) updateFields.description = description;
+
+    // Validate status if provided
+    const validStatus = ["todo", "in_progress", "done"];
+    if (status !== undefined) {
+      if (!validStatus.includes(status)) {
+        return res.status(400).json({ error: "Invalid status value" });
+      }
+      updateFields.status = status;
+    }
+
+    // Prevent empty update request
+    if (Object.keys(updateFields).length === 0) {
+      return res.status(400).json({ error: "No fields to update" });
+    }
+
+    // Update task in database
+    const { data, error } = await supabase
+      .from("tasks")
+      .update(updateFields)
+      .eq("id", id)
+      .select();
+
+    if (error) throw error;
+
+    // Handle case where task does not exist
+    if (!data || data.length === 0) {
+      return res.status(404).json({ error: "Task not found" });
+    }
+
+    const updatedTask = data[0];
+
+    // Emit real-time update event
+    const io = req.app.get("io");
+    if (io && updatedTask) {
+      io.emit("task-updated", updatedTask);
+    }
+
+    // Send updated task as response
+    res.status(200).json(updatedTask);
   } catch (error) {
     console.error("Error updating task:", error);
     res.status(500).json({ error: "Failed to update task" });

--- a/backend/routes/tasks.routes.js
+++ b/backend/routes/tasks.routes.js
@@ -3,6 +3,7 @@ import {
   getTasks,
   createTask,
   updateTaskStatus,
+  updateTask,
   deleteTask,
 } from "../controllers/tasks.controller.js";
 
@@ -11,6 +12,8 @@ const router = express.Router();
 router.get("/", getTasks);
 router.post("/", createTask);
 router.patch("/:id", updateTaskStatus);
+router.patch("/:id/edit", updateTask);
 router.delete("/:id", deleteTask);
+
 
 export default router;

--- a/frontend/app/components/kanban/KanbanBoard.tsx
+++ b/frontend/app/components/kanban/KanbanBoard.tsx
@@ -37,6 +37,32 @@ export function KanbanBoard() {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [socket, setSocket] = useState<any>(null);
 
+  const handleEditTask = async (task: Task) => {
+  const newTitle = window.prompt("Edit title:", task.title);
+  if (!newTitle) return;
+
+  const newDescription = window.prompt(
+    "Edit description:",
+    task.description
+  );
+
+  try {
+    await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000"}/api/tasks/${task.id}/edit`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: newTitle,
+          description: newDescription,
+        }),
+      }
+    );
+  } catch (error) {
+    console.error("Failed to update task", error);
+  }
+};
+
   useEffect(() => {
     // Assuming backend runs on 5000 in dev
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
@@ -60,6 +86,10 @@ export function KanbanBoard() {
 
     newSocket.on("task-created", (newTask: Task) => {
       setTasks((prev) => [...prev, newTask].sort((a, b) => a.position - b.position));
+    });
+
+    newSocket.on("task-updated", (updatedTask: Task) => {
+      setTasks((prev) => prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)));
     });
 
     newSocket.on("task-deleted", (taskId: string) => {
@@ -247,6 +277,7 @@ export function KanbanBoard() {
             tasks={tasks.filter((task) => task.status === col.id)}
             onCreateTask={() => handleCreateTask(col.id)}
             onDeleteTask={handleDeleteTask}
+            onEditTask={handleEditTask}
           />
         ))}
       </div>

--- a/frontend/app/components/kanban/KanbanCard.tsx
+++ b/frontend/app/components/kanban/KanbanCard.tsx
@@ -10,9 +10,10 @@ interface Props {
   task: Task;
   isOverlay?: boolean;
   onDelete?: () => void;
+  onEditTask?: (task: Task) => void;
 }
 
-export function KanbanCard({ task, isOverlay, onDelete }: Props) {
+export function KanbanCard({ task, isOverlay, onDelete, onEditTask }: Props) {
   const {
     setNodeRef,
     attributes,
@@ -61,21 +62,37 @@ export function KanbanCard({ task, isOverlay, onDelete }: Props) {
           <h4 className="text-sm font-semibold text-slate-800 leading-tight">{task.title}</h4>
         </div>
         
-        {onDelete && (
+        <div className="flex items-center gap-1">
+          {/* Edit Button */}
           <button
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
-              onDelete();
+              onEditTask?.(task);
             }}
-            className="invisible flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition hover:bg-red-50 hover:text-red-500 group-hover:visible"
-            title="Delete Task"
-          >
-            <Trash2 size={14} />
-          </button>
-        )}
+            className="invisible flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition hover:bg-blue-50 hover:text-blue-500 group-hover:visible"
+            title="Edit Task"
+            
+            >
+              ✏️
+            </button>
+
+           {/* Delete Button */}
+            {onDelete && (
+              <button
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                className="invisible flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition hover:bg-red-50 hover:text-red-500 group-hover:visible"
+                title="Delete Task"
+
+                >
+                  <Trash2 size={14} />
+                </button>
+            )}
+          </div>
       </div>
       
       {task.description && (

--- a/frontend/app/components/kanban/KanbanColumn.tsx
+++ b/frontend/app/components/kanban/KanbanColumn.tsx
@@ -15,9 +15,10 @@ interface Props {
   tasks: Task[];
   onCreateTask: () => void;
   onDeleteTask: (id: string) => void;
+  onEditTask: (task: Task) => void;
 }
 
-export function KanbanColumn({ column, tasks, onCreateTask, onDeleteTask }: Props) {
+export function KanbanColumn({ column, tasks, onCreateTask, onDeleteTask, onEditTask  }: Props) {
   const { setNodeRef, isOver } = useDroppable({
     id: column.id,
     data: {
@@ -54,6 +55,7 @@ export function KanbanColumn({ column, tasks, onCreateTask, onDeleteTask }: Prop
                   key={task.id}
                   task={task}
                   onDelete={() => onDeleteTask(task.id)}
+                  onEditTask={onEditTask}
                 />
               ))
             )}


### PR DESCRIPTION
## **NSOC'26**

### **Problem**

The Workspace Tasks section allows creating, moving, and deleting tasks, but there was no way to edit an existing task.
Because of this, users could not update task title or description without deleting and recreating the task.

---

### **Solution**

Implemented task edit functionality to allow users to update task details directly from the Kanban board.

---

### **Changes Made**

#### **Backend**

* Added new controller `updateTask` to handle updates for:

  * title
  * description
  * status (optional)
* Added new endpoint:

  * `PATCH /api/tasks/:id/edit`
* Validated request data and handled edge cases
* Emitted Socket.IO event `task-updated` for real-time sync

---

#### **Frontend**

* Added edit button on each task card
* Implemented `handleEditTask` in `KanbanBoard`
* Passed edit handler through:

  * `KanbanColumn`
  * `KanbanCard`
* Used prompt-based input for updating task details
* Integrated API call with backend update route
* Synced UI with real-time updates via socket listener

---

### **Result**

* Users can edit task title and description directly
* No need to delete and recreate tasks
* Changes persist after refresh
* Updates reflect instantly across multiple clients

---

### **Outcome**

* Completes CRUD functionality for tasks
* Improves usability of the Kanban board
* Maintains consistency between frontend and backend

---

### **ScreenShot**

<img width="1905" height="927" alt="Screenshot from 2026-05-05 02-20-36" src="https://github.com/user-attachments/assets/33977249-4b2b-48db-8094-9196ccac6188" />

---

<img width="1905" height="927" alt="Screenshot from 2026-05-05 02-25-19" src="https://github.com/user-attachments/assets/bfe74fdc-532d-439a-8254-37bf6586bf2c" />


---

Kindly Review my pr.
Thank You! (NSOC'26)
