### PR TITLE
fix: maintain consistent task ordering after drag and drop [NSOC'26]

### DIFF
--- a/frontend/app/components/kanban/KanbanBoard.tsx
+++ b/frontend/app/components/kanban/KanbanBoard.tsx
@@ -173,55 +173,90 @@ export function KanbanBoard() {
   };
 
   const handleDragEnd = async (event: any) => {
-    setActiveTask(null);
-    const { active, over } = event;
-    if (!over) return;
+  setActiveTask(null);
 
-    const activeId = active.id;
-    const overId = over.id;
+  const { active, over } = event;
+  if (!over) return;
 
-    const activeTask = tasks.find((t) => t.id === activeId);
-    if (!activeTask) return;
+  const activeId = active.id;
+  const overId = over.id;
 
-    let newStatus = activeTask.status;
-    
-    if (over.data.current?.type === "Column") {
-      newStatus = over.id as any;
-    } else if (over.data.current?.type === "Task") {
-      const overTask = tasks.find((t) => t.id === overId);
-      if (overTask) {
-        newStatus = overTask.status;
-      }
+  const activeTask = tasks.find((t) => t.id === activeId);
+  if (!activeTask) return;
+
+  let newStatus = activeTask.status;
+
+  if (over.data.current?.type === "Column") {
+    newStatus = over.id as any;
+  } else if (over.data.current?.type === "Task") {
+    const overTask = tasks.find((t) => t.id === overId);
+    if (overTask) {
+      newStatus = overTask.status;
     }
+  }
 
-    const sameColumnTasks = tasks.filter(t => t.status === newStatus);
-    const newPosition = sameColumnTasks.length;
-    const updatedTask = { ...activeTask, status: newStatus, position: newPosition };
-    const newTasksList = tasks.map(t =>
-      t.id === activeId ? updatedTask : t
+  // Create updated task list
+  let updatedTasks = [...tasks];
+
+  // Update dragged task status
+  updatedTasks = updatedTasks.map((task) =>
+    task.id === activeId
+      ? { ...task, status: newStatus }
+      : task
+  );
+
+  // Get tasks of affected column
+  const columnTasks = updatedTasks
+    .filter((task) => task.status === newStatus)
+    .sort((a, b) => a.position - b.position);
+
+  // Reassign positions sequentially
+  const reorderedTasks = columnTasks.map((task, index) => ({
+    ...task,
+    position: index,
+  }));
+
+  // Merge back updated positions
+  updatedTasks = updatedTasks.map((task) => {
+    const updated = reorderedTasks.find((t) => t.id === task.id);
+    return updated || task;
+  });
+
+  // Update frontend state
+  setTasks(updatedTasks);
+
+  try {
+    // Send updates for all affected tasks
+    await Promise.all(
+      reorderedTasks.map((task) =>
+        fetch(
+          `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000"}/api/tasks/${task.id}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              status: task.status,
+              position: task.position,
+            }),
+          }
+        )
+      )
     );
 
-    setTasks(newTasksList);
-
-    try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000"}/api/tasks/${activeId}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ status: newStatus, position: newPosition }),
+    // Emit socket updates
+    if (socket) {
+      reorderedTasks.forEach((task) => {
+        socket.emit("task-moved", task);
       });
-
-      if (res.ok) {
-        const savedTask = await res.json();
-        if (socket) {
-          socket.emit("task-moved", savedTask);
-        }
-      }
-    } catch (error) {
-      console.error("Failed to update task", error);
     }
-  };
+  } catch (error) {
+    console.error("Failed to update task positions", error);
+  }
+};
+
+    
 
   const handleCreateTask = async (columnId: string) => {
     const title = window.prompt("Task Title:");


### PR DESCRIPTION
## Problem

Currently, when tasks are reordered within a column, only the dragged task’s position gets updated. Other tasks retain their previous position values, which leads to inconsistent ordering after refresh and may create duplicate positions in the database.

## Solution

Implemented sequential position reassignment for all tasks in the affected column whenever a drag-and-drop action occurs.

The frontend now recalculates positions for all reordered tasks and syncs them with the backend to maintain consistent ordering across refreshes and connected clients.

## Changes Made

### Frontend

* Updated drag-and-drop handling logic in `KanbanBoard`
* Recalculated positions for all tasks after reordering
* Synced updated positions with backend API calls
* Ensured frontend state stays consistent after task movement

### Backend

* Reused the existing task update endpoint to persist updated task positions
* Synced reordered task data with the database through sequential update requests

## Result

* Task ordering remains consistent after refresh
* No duplicate or conflicting position values
* Drag-and-drop changes persist correctly
* Ordering stays synchronized across clients

## Testing

* Reordered tasks within the same column
* Moved tasks across different columns
* Refreshed the application after updates
* Verified ordering consistency after reload
* Confirmed task positions update correctly in the database

## Screenshots

<img width="1674" height="960" alt="Screenshot from 2026-05-06 10-59-23" src="https://github.com/user-attachments/assets/d1ad1935-a22e-4eb2-8b38-c501be6518dd" />

---
After refresh Task ordering remains consistent

<img width="1674" height="960" alt="Screenshot from 2026-05-06 10-59-30" src="https://github.com/user-attachments/assets/26e782eb-ddaf-4e09-9295-bede9782d0b1" />

---

Kindly review my pr.
NSOC'26
