### PR TITLE
feat: add forgot password and reset password flow

### DIFF
--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { supabase, isSupabaseConfigured } from "@/app/lib/supabase";
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleReset = async () => {
+    setErrorMsg("");
+    setSuccessMsg("");
+
+    if (!supabase) {
+      setErrorMsg("Supabase is not configured.");
+      return;
+    }
+
+    if (!email.trim()) {
+      setErrorMsg("Please enter your email address.");
+      return;
+    }
+
+    setLoading(true);
+    const { error } = await supabase.auth.resetPasswordForEmail(email.trim(), {
+      redirectTo: `${window.location.origin}/reset-password`,
+    });
+    setLoading(false);
+
+    if (error) {
+      setErrorMsg(error.message);
+    } else {
+      setSuccessMsg(
+        "Password reset email sent! Please check your inbox and follow the link."
+      );
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center px-4"
+      style={{ background: "var(--bg-page)" }}
+    >
+      <div
+        className="panel w-full max-w-sm rounded-2xl p-8"
+        style={{
+          background: "var(--bg-panel)",
+          border: "1px solid var(--line)",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.06)",
+        }}
+      >
+        {/* Logo */}
+        <div className="mb-6 flex items-center gap-2">
+          <div
+            className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold text-white"
+            style={{ background: "var(--accent)" }}
+          >
+            FF
+          </div>
+          <span
+            className="text-sm font-semibold tracking-tight"
+            style={{ color: "var(--text-main)" }}
+          >
+            FlowForge
+          </span>
+        </div>
+
+        <h1
+          className="text-2xl font-bold tracking-tight mb-1"
+          style={{ color: "var(--text-main)" }}
+        >
+          Forgot Password?
+        </h1>
+        <p className="text-sm mb-6" style={{ color: "var(--text-muted)" }}>
+          Enter your email and we'll send you a reset link.
+        </p>
+
+        <input
+          type="email"
+          className="w-full rounded-xl px-4 py-2.5 mb-4 text-sm focus:outline-none"
+          style={{
+            background: "var(--bg-soft)",
+            border: "1px solid var(--line)",
+            color: "var(--text-main)",
+          }}
+          placeholder="Email address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+
+        {errorMsg && (
+          <div
+            className="mb-4 rounded-xl px-4 py-2.5 text-sm"
+            style={{
+              background: "var(--bg-soft)",
+              border: "1px solid var(--line)",
+              color: "var(--text-main)",
+            }}
+          >
+            ⚠ {errorMsg}
+          </div>
+        )}
+
+        {successMsg && (
+          <div className="mb-4 rounded-xl px-4 py-2.5 text-sm text-green-600"
+            style={{
+              background: "var(--bg-soft)",
+              border: "1px solid var(--line)",
+            }}
+          >
+            ✓ {successMsg}
+          </div>
+        )}
+
+        <button
+          onClick={handleReset}
+          disabled={loading || !isSupabaseConfigured}
+          className="accent-btn w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {loading ? "Sending reset link..." : "Send Reset Link"}
+        </button>
+
+        <p className="mt-5 text-center text-sm" style={{ color: "var(--text-muted)" }}>
+          Remember your password?{" "}
+          <Link
+            href="/login"
+            className="font-medium underline underline-offset-4"
+            style={{ color: "var(--accent)" }}
+          >
+            Back to Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -64,6 +64,16 @@ export default function Login() {
           onChange={(e) => setPassword(e.target.value)}
         />
 
+        <div className="flex justify-end mb-4">
+          <Link
+            href="/forgot-password"
+            className="text-xs underline underline-offset-4"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Forgot password?
+          </Link>
+        </div>
+        
         <button
           onClick={handleLogin}
           disabled={loading || !isSupabaseConfigured}

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { supabase, isSupabaseConfigured } from "@/app/lib/supabase";
+
+export default function ResetPassword() {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    // Supabase puts the session tokens in the URL hash after redirect
+    // We listen for the auth state change to confirm the session is valid
+    if (!supabase) return;
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        if (event === "PASSWORD_RECOVERY" && session) {
+          setSessionReady(true);
+        }
+      }
+    );
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleUpdatePassword = async () => {
+    setErrorMsg("");
+    setSuccessMsg("");
+
+    if (!supabase) {
+      setErrorMsg("Supabase is not configured.");
+      return;
+    }
+
+    if (!password || !confirmPassword) {
+      setErrorMsg("Please fill in both password fields.");
+      return;
+    }
+
+    if (password.length < 8) {
+      setErrorMsg("Password must be at least 8 characters.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setErrorMsg("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    const { error } = await supabase.auth.updateUser({ password });
+    setLoading(false);
+
+    if (error) {
+      setErrorMsg(error.message);
+    } else {
+      setSuccessMsg("Password updated successfully! Redirecting to login...");
+      setTimeout(() => router.push("/login"), 2500);
+    }
+  };
+
+  const inputStyle = {
+    background: "var(--bg-soft)",
+    border: "1px solid var(--line)",
+    color: "var(--text-main)",
+  };
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center px-4"
+      style={{ background: "var(--bg-page)" }}
+    >
+      <div
+        className="panel w-full max-w-sm rounded-2xl p-8"
+        style={{
+          background: "var(--bg-panel)",
+          border: "1px solid var(--line)",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.06)",
+        }}
+      >
+        {/* Logo */}
+        <div className="mb-6 flex items-center gap-2">
+          <div
+            className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold text-white"
+            style={{ background: "var(--accent)" }}
+          >
+            FF
+          </div>
+          <span
+            className="text-sm font-semibold tracking-tight"
+            style={{ color: "var(--text-main)" }}
+          >
+            FlowForge
+          </span>
+        </div>
+
+        <h1
+          className="text-2xl font-bold tracking-tight mb-1"
+          style={{ color: "var(--text-main)" }}
+        >
+          Reset Password
+        </h1>
+        <p className="text-sm mb-6" style={{ color: "var(--text-muted)" }}>
+          Enter your new password below.
+        </p>
+
+        {/* New Password */}
+        <div className="relative mb-3">
+          <input
+            type={showPassword ? "text" : "password"}
+            className="w-full rounded-xl px-4 py-2.5 pr-16 text-sm focus:outline-none"
+            style={inputStyle}
+            placeholder="New Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-xs"
+            style={{ color: "var(--text-muted)" }}
+          >
+            {showPassword ? "Hide" : "Show"}
+          </button>
+        </div>
+
+        {/* Confirm Password */}
+        <div className="relative mb-4">
+          <input
+            type={showConfirm ? "text" : "password"}
+            className="w-full rounded-xl px-4 py-2.5 pr-16 text-sm focus:outline-none"
+            style={inputStyle}
+            placeholder="Confirm New Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirm((v) => !v)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-xs"
+            style={{ color: "var(--text-muted)" }}
+          >
+            {showConfirm ? "Hide" : "Show"}
+          </button>
+        </div>
+
+        {/* Password match indicator */}
+        {confirmPassword && (
+          <p className={`text-xs mb-3 ${password === confirmPassword ? "text-green-500" : "text-red-500"}`}>
+            {password === confirmPassword ? "✓ Passwords match" : "✗ Passwords do not match"}
+          </p>
+        )}
+
+        {errorMsg && (
+          <div
+            className="mb-4 rounded-xl px-4 py-2.5 text-sm"
+            style={{
+              background: "var(--bg-soft)",
+              border: "1px solid var(--line)",
+              color: "var(--text-main)",
+            }}
+          >
+            ⚠ {errorMsg}
+          </div>
+        )}
+
+        {successMsg && (
+          <div className="mb-4 rounded-xl px-4 py-2.5 text-sm text-green-600"
+            style={{
+              background: "var(--bg-soft)",
+              border: "1px solid var(--line)",
+            }}
+          >
+            ✓ {successMsg}
+          </div>
+        )}
+
+        <button
+          onClick={handleUpdatePassword}
+          disabled={loading || !isSupabaseConfigured}
+          className="accent-btn w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {loading ? "Updating password..." : "Update Password"}
+        </button>
+
+        <p className="mt-5 text-center text-sm" style={{ color: "var(--text-muted)" }}>
+          <Link
+            href="/login"
+            className="font-medium underline underline-offset-4"
+            style={{ color: "var(--accent)" }}
+          >
+            Back to Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the complete forgot/reset password authentication 
flow as described in Issue #67.

## Changes Made
- `frontend/app/login/page.tsx` — added "Forgot password?" 
   link below password input field
- `frontend/app/forgot-password/page.tsx` — new page with 
   email input that triggers Supabase resetPasswordForEmail()
- `frontend/app/reset-password/page.tsx` — new page that 
   handles the reset token and calls Supabase updateUser()

## User Flow
Login page 
  → clicks "Forgot password?" 
  → /forgot-password (enters email) 
  → reset email sent ✓ 
  → user clicks email link 
  → /reset-password (enters new password) 
  → redirected to /login ✓

## Styling
All new pages use existing CSS variables 
(--bg-page, --bg-panel, --accent, --text-main, --text-muted) 
consistent with the homepage theme.

## Screenshots
### Login page with "Forgot password?" link
<img width="1915" height="971" alt="Screenshot 2026-05-18 103458" src="https://github.com/user-attachments/assets/521aa0b5-1e35-42ab-a548-50b1ec93e480" />

### /forgot-password page
<img width="1915" height="968" alt="Screenshot 2026-05-18 103545" src="https://github.com/user-attachments/assets/b495545a-1d8a-45a3-bad5-9073a52d793e" />

### /forgot-password — success state (email sent)
<img width="1918" height="957" alt="Screenshot 2026-05-18 103608" src="https://github.com/user-attachments/assets/81b70caf-afee-4da5-b6b0-6d8cf7fa1aeb" />

## Issue
Closes #67

nsoc26