### PR TITLE
fix: Add .env.example documenting required Supabase server-side keys for signup API route

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,27 @@
+# ============================================
+# FlowForge Frontend — Environment Variables
+# ============================================
+# Copy this file and rename it to .env.local
+# Fill in your actual values below
+# NEVER commit .env.local to version control
+# ============================================
+
+# Backend API URL
+NEXT_PUBLIC_BACKEND_URL=http://localhost:5000
+
+# -----------------------------------------------
+# Supabase — Public keys (safe to expose in browser)
+# Get these from: Supabase Dashboard > Project Settings > Data API
+# -----------------------------------------------
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_public_key_here
+
+# -----------------------------------------------
+# Supabase — Server-side keys (NEVER expose these in browser)
+# Required by: frontend/app/api/auth/signup/route.ts
+# Uses auth.admin.createUser() which requires service_role key
+# Get from: Supabase Dashboard > Project Settings > Data API > service_role
+# WARNING: This key has admin privileges — keep it secret!
+# -----------------------------------------------
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_SERVICE_KEY=your_service_role_key_here

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
The signup page was completely broken with 404/400 errors
because the required server-side environment variables were
not documented anywhere in the project.

## Root Cause
`frontend/app/api/auth/signup/route.ts` uses Supabase
admin client which requires two server-side variables:
- `SUPABASE_URL`
- `SUPABASE_SERVICE_KEY` (service_role key — NOT anon key)

These are different from the public `NEXT_PUBLIC_` variables
already in use. Without them the route failed with:
- 404 Not Found (env vars missing entirely)
- 401 Invalid API key (wrong key used)

## Fix
1. Created `frontend/.env.example` documenting ALL required
   environment variables with clear comments explaining:
   - Which variables are public vs server-side only
   - Where to get each value in Supabase dashboard
   - Why service_role key is needed (not anon key)
   - Security warnings about never committing secrets

2. Updated `frontend/.gitignore` to add `!.env.example`
   exception so the example file can be tracked by git
   (previously `.env*` pattern was ignoring all env files
   including .env.example)

## Proof — Signup Working After Fix
- POST /api/auth/signup → 201 Created ✅
- User redirected to /dashboard after signup ✅
- User account created successfully in Supabase ✅

## Files Changed
- `frontend/.env.example` ← new file
- `frontend/.gitignore`   ← added !.env.example exception

## Issue
Closes #69

nsoc26