### PR TITLE
feat: add enter key support in team chat(NSOC'26)

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -226,6 +226,23 @@ socket.on("newMessage", (msg) => {
   });
 }
 
+
+
+function handleKeyDown(
+  e: React.KeyboardEvent<HTMLTextAreaElement>
+) {
+  // Shift + Enter → new line
+  if (e.key === "Enter" && e.shiftKey) {
+    return;
+  }
+
+  // Enter → send message
+  if (e.key === "Enter") {
+    e.preventDefault();
+    handleSend();
+  }
+}
+
   // TYPING
   function handleTyping(e: any) {
     setInput(e.target.value);
@@ -827,15 +844,17 @@ return (
       </button>
 
       {/* MESSAGE INPUT */}
-      <input
-        value={input}
-        onChange={handleTyping}
-        placeholder={
-          editingMessageId
-            ? "Edit your message..."
-            : "Type message"
-        }
-        className="min-w-[140px] flex-1 rounded-2xl border border-(--line) bg-white px-4 py-3 text-sm shadow-sm outline-none focus:border-slate-400"
+      <textarea
+          value={input}
+          onChange={handleTyping}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            editingMessageId
+              ? "Edit your message..."
+              : "Type message"
+            }
+            rows={1}
+            className="min-w-[140px] flex-1 resize-none rounded-2xl border border-(--line) bg-white px-4 py-3 text-sm shadow-sm outline-none focus:border-slate-400"
       />
 
       {/* SEND BUTTON */}


### PR DESCRIPTION
## NSOC'26

### Overview
This PR improves the Team Chat experience by adding keyboard support for sending messages directly using the Enter key.

Users can now send messages faster while still being able to create multiline messages using Shift + Enter.

---

## Related Issue
Closes #65

---

## Features Added

### Enter Key Support
- Pressing `Enter` now sends the message instantly

### Multiline Message Support
- Pressing `Shift + Enter` creates a new line
- Prevents accidental message sending while typing multiline messages

### Chat Input Improvements
- Replaced single-line input with responsive textarea
- Preserved existing Team Chat styling and layout

---

## Technical Improvements
- Added keyboard event handling for textarea
- Added conditional Enter/Shift+Enter behavior
- Prevented default form submission behavior when sending messages

---

## Tech Stack
- Next.js
- React
- Tailwind CSS
- Socket.IO

---

## Tested
- Enter key message sending
- Shift + Enter multiline messages
- Empty message prevention
- Existing send button functionality
- Responsive textarea behavior

---

## Preview
- Keyboard-based message sending
- Multiline chat input support