### PR TITLE
feat: add auto focus to chat input (NSOC'26)

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -48,6 +48,7 @@ export default function ChatPage() {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const isAtBottomRef = useRef(true);
   const [unreadCount, setUnreadCount] = useState(0);
   
@@ -152,6 +153,11 @@ socket.on("newMessage", (msg) => {
       socketRef.current.emit("join", username);
     }
   }, [username]);
+
+  //autofocus effect
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   // SMART AUTO SCROLL (FIXED)
   useEffect(() => {
@@ -845,6 +851,7 @@ return (
 
       {/* MESSAGE INPUT */}
       <textarea
+          ref={inputRef}
           value={input}
           onChange={handleTyping}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
## NSOC'26

### Overview
This PR improves Team Chat usability by automatically focusing the chat input field when the page loads.

Users can now start typing messages instantly without manually clicking the input field.

---

## Related Issue
Closes #73

---

## Improvements Made

### Auto Focus Support
- Added automatic focus to the Team Chat message input
- Users can instantly start typing after opening the chat page

### Input Handling Improvements
- Added React ref handling for chat textarea
- Added focus management using `useEffect`

### UX Improvements
- Faster message interaction flow
- Improved chat accessibility and usability
- Preserved existing chat UI and functionality

---

## Tech Stack
- Next.js
- React
- Tailwind CSS
- Socket.IO

---

## Tested
- Auto focus on page load
- Existing message sending flow
- Enter key support
- Shift + Enter multiline support
- Responsive textarea behavior

---

## Preview
- Instant typing experience on chat open