### PR TITLE
fix: Resolve Recharts -1 width/height console error on Dashboard Productivity Analytics chart

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -21,7 +21,12 @@ import {
 
 export default function Dashboard() {
   const [filter, setFilter] = useState("This Month");
+  const [mounted, setMounted] = useState(false);
 
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  
   const user = {
     name: "Anshi",
     role: "admin",
@@ -186,8 +191,9 @@ export default function Dashboard() {
           </div>
 
           {/* ✅ FIX: Use inline styles for guaranteed dimensions */}
-          <div style={{ width: "100%", height: "300px" }}>
-            <ResponsiveContainer width="100%" height="100%">
+          <div style={{ width: "100%", minWidth: 0, height: "300px", overflow: "hidden" }}>
+            {mounted && (
+            <ResponsiveContainer width="100%" height={300}>
               <LineChart data={chartData}>
                 <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
                 <XAxis dataKey="name" />
@@ -203,6 +209,7 @@ export default function Dashboard() {
                 />
               </LineChart>
             </ResponsiveContainer>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Fixed the repeated Recharts console error on the Dashboard 
page where the chart received -1 as width and height 
during initial render.

## Root Cause
Three issues combined caused the -1 dimension error:
1. No `minWidth: 0` on wrapper div — Recharts couldn't 
   measure the container correctly
2. `height="100%"` on ResponsiveContainer required 
   container height measurement which wasn't ready
3. Chart rendered during SSR/initial paint before 
   DOM layout had settled

## Fix
In `frontend/app/dashboard/page.tsx`:
1. Added `useEffect` with `mounted` state — chart only 
   renders after component is fully mounted in browser
2. Added `minWidth: 0` and `overflow: hidden` to 
   the chart wrapper div
3. Changed `height="100%"` to `height={300}` on 
   ResponsiveContainer — fixed pixel height bypasses 
   container measurement entirely

## Before
Console: The width(-1) and height(-1) of chart should 
be greater than 0... (repeated 10+ times on every load)

## After
- ✅ Zero Recharts width/height console errors
- ✅ Chart renders correctly on all screen sizes  
- ✅ Smooth render on initial page load

## Screenshots
<img width="1920" height="975" alt="image" src="https://github.com/user-attachments/assets/e31ea7f4-0a65-4a65-b240-12335a4d7409" />

<img width="1920" height="974" alt="image" src="https://github.com/user-attachments/assets/062702cc-95db-40f8-8afc-abd9dab18bca" />

## Files Changed
- `frontend/app/dashboard/page.tsx` — only file modified

## Issue
Closes #71

nsoc26