### PR TITLE
fix: Replace hardcoded username "Anshi" and static stats with real Supabase session data

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -27,10 +27,22 @@ export default function Dashboard() {
     setMounted(true);
   }, []);
   
-  const user = {
-    name: "Anshi",
-    role: "admin",
-  };
+  const [user, setUser] = useState({ name: "User", role: "member" });
+
+  useEffect(() => {
+    const getUser = async () => {
+      if (!supabase) return;
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.user) {
+        const name =
+          session.user.user_metadata?.full_name ||
+          session.user.email ||
+          "User";
+        setUser({ name, role: "member" });
+      }
+    };
+    getUser();
+  }, []);
 
   // ✅ Dynamic chart data based on filter
   const chartData =
@@ -52,9 +64,9 @@ export default function Dashboard() {
         ];
 
   const stats = [
-    { title: "Velocity", value: "+18%", icon: TrendingUp },
-    { title: "Deploys", value: "24", icon: Rocket },
-    { title: "Incidents", value: "2", icon: AlertTriangle },
+    { title: "Velocity", value: "—", icon: TrendingUp },
+    { title: "Deploys", value: "—", icon: Rocket },
+    { title: "Incidents", value: "—", icon: AlertTriangle },
   ];
 
   const [team, setTeam] = useState<{ name: string; email: string }[]>([]);


### PR DESCRIPTION
## Summary
Fixed the Dashboard page which was showing hardcoded 
username "Anshi" and fake static stats to every user 
regardless of who was actually logged in.

## Changes Made
Only `frontend/app/dashboard/page.tsx` was modified:

1. Replaced hardcoded `user` object with dynamic 
   state that fetches real name from Supabase session:
   - Uses `session.user.user_metadata?.full_name`
   - Falls back to `session.user.email`
   - Falls back to "User" if nothing found

2. Replaced hardcoded stats values (+18%, 24, 2) 
   with "—" placeholder indicating data is not 
   yet integrated with real backend

## Before
- Every user saw "Welcome back, Anshi 👋"
- Stats showed same fake numbers for everyone

## After
- ✅ Shows real logged-in user's name
- ✅ Stats show "—" as honest placeholder
- ✅ Connected to real Supabase auth session

## Screenshots
<img width="1883" height="952" alt="Screenshot 2026-05-21 152053" src="https://github.com/user-attachments/assets/3724fd69-f2be-406d-9d57-5b49ebe482a5" />

## Files Changed
- `frontend/app/dashboard/page.tsx` — only file modified

## Issue
Closes #82

nsoc26