### PR TITLE
feat(chat): clear search input with ESC key (NSOC'26)

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -354,7 +354,12 @@ function stopRecording() {
     // load message into input
     setInput(currentText);
 }
+    function clearSearch() {
+      setSearchQuery("");
+      setActiveMessageId(null);
 
+      matchedMessageRef.current = null;
+    }
 
 const filteredMessages = messages.filter((msg) => {
   const query = searchQuery.toLowerCase();
@@ -418,13 +423,18 @@ return (
       type="text"
       value={searchQuery}
       onChange={(e) => setSearchQuery(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          clearSearch();
+        }
+     }}
       placeholder="Search messages or users..."
       className="w-full rounded-xl border border-(--line) px-4 py-2 pr-10 text-sm outline-none transition focus:border-slate-400"
-    />
+  />
 
     {searchQuery && (
       <button
-        onClick={() => setSearchQuery("")}
+        onClick={clearSearch}
         className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-slate-400 hover:text-slate-600"
       >
         ✕


### PR DESCRIPTION
### NSOC'26

## PR Description

### Summary

Improved keyboard accessibility in Team Chat search by adding support for clearing the search input using the `Escape (ESC)` key.

### Changes Made

* Added `clearSearch()` helper function
* Added `onKeyDown` event handler to search input
* Detects `Escape` key press
* Reused existing clear button logic through shared `clearSearch()` function
* Clears:

  * search query
  * filtered messages
  * highlighted search matches

### Result

Users can now quickly reset chat search results using keyboard shortcuts for a smoother and more accessible experience.

### Tech Stack

* Next.js
* React
* Tailwind CSS

## Closes #86