### PR TITLE
fix: add page titles and meta tags for all major routes [nsoc26]

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+};
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,16 @@
 import "./globals.css";
+import type { Metadata } from "next";
 import AppShell from "@/app/components/AppShell";
 import { ToastProvider } from "@/app/context/ToastContext";
+
+export const metadata: Metadata = {
+  title: {
+    default: "FlowForge",
+    template: "%s — FlowForge",
+  },
+  description:
+    "Kanban boards, team chat, and project tracking — without the extra tools you don't need.",
+};
 
 export default function RootLayout({
   children,

--- a/frontend/app/login/layout.tsx
+++ b/frontend/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/app/projects/layout.tsx
+++ b/frontend/app/projects/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Projects",
+};
+
+export default function ProjectsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/app/signup/layout.tsx
+++ b/frontend/app/signup/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Create Account",
+};
+
+export default function SignupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
Added page-specific titles and global meta tags to 
FlowForge. Previously all pages showed a blank or 
generic browser tab title.

## Changes Made

### Modified Files
1. `frontend/app/layout.tsx`
   - Added global Metadata export with title template
   - Default title: "FlowForge"
   - Template: "%s — FlowForge" for all pages
   - Added meta description for SEO

### New Files Created
2. `frontend/app/dashboard/layout.tsx`
   - Title: "Dashboard — FlowForge"

3. `frontend/app/projects/layout.tsx`
   - Title: "Projects — FlowForge"

4. `frontend/app/login/layout.tsx`
   - Title: "Sign In — FlowForge"

5. `frontend/app/signup/layout.tsx`
   - Title: "Create Account — FlowForge"

## Why Route Layouts Instead of Page Metadata?
All page components (dashboard, projects, login, signup)
use "use client" directive which prevents direct metadata
exports. Route-level layout.tsx files are server components
by default, making them the correct Next.js approach for
adding metadata to client component pages.

## Before
- All pages showed blank or "localhost:3000" in browser tab
- No meta description for any route

## After
- localhost:3000 → "FlowForge"
- localhost:3000/dashboard → "Dashboard — FlowForge"
- localhost:3000/projects → "Projects — FlowForge"
- localhost:3000/login → "Sign In — FlowForge"
- localhost:3000/signup → "Create Account — FlowForge"

## Screenshots
<img width="1920" height="964" alt="image" src="https://github.com/user-attachments/assets/dc3fbd6d-e82a-488d-a50d-64dcaa9ed707" />
<img width="1920" height="939" alt="image" src="https://github.com/user-attachments/assets/de871e6b-6e68-43a5-8f9c-c95392a425a8" />

## Files Changed
- `frontend/app/layout.tsx` ← modified
- `frontend/app/dashboard/layout.tsx` ← new
- `frontend/app/projects/layout.tsx` ← new
- `frontend/app/login/layout.tsx` ← new
- `frontend/app/signup/layout.tsx` ← new

## Issue
Closes #89

nsoc26