### PR TITLE
feat: add sprint-to-sprint comparison analytics (NSOC'26)

### DIFF
--- a/frontend/app/components/analytics-comp/AnalyticsHeader.tsx
+++ b/frontend/app/components/analytics-comp/AnalyticsHeader.tsx
@@ -1,29 +1,33 @@
 "use client";
 
 type AnalyticsHeaderProps = {
-  sprint: string;
+  sprintA: string;
+  sprintB: string;
   sprints: string[];
   query: string;
   onQueryChange: (query: string) => void;
-  onSprintChange: (sprint: string) => void;
+  onSprintAChange: (sprint: string) => void;
+  onSprintBChange: (sprint: string) => void;
 };
 
 export default function AnalyticsHeader({
-  sprint,
+  sprintA,
+  sprintB,
   sprints,
   query,
   onQueryChange,
-  onSprintChange,
+  onSprintAChange,
+  onSprintBChange,
 }: AnalyticsHeaderProps) {
   return (
     <div className="border-b border-outline-variant bg-white px-6 py-4">
       <div className="mx-auto flex max-w-7xl flex-col gap-3 lg:flex-row lg:items-center">
-
         <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+
           <select
-            value={sprint}
+            value={sprintA}
             onChange={(event) =>
-              onSprintChange(event.target.value)
+              onSprintAChange(event.target.value)
             }
             className="
               rounded-lg border border-outline-variant
@@ -35,6 +39,26 @@ export default function AnalyticsHeader({
           >
             {sprints.map((item) => (
               <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={sprintB}
+            onChange={(event) =>
+              onSprintBChange(event.target.value)
+            }
+            className="
+              rounded-lg border border-outline-variant
+              bg-surface-container-low
+              px-3 py-2
+              outline-none transition
+              focus:border-primary
+            "
+          >
+            {sprints.map((item) => (
+              <option key={`compare-${item}`} value={item}>
                 {item}
               </option>
             ))}

--- a/frontend/app/insights/analytics/page.tsx
+++ b/frontend/app/insights/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { supabase } from "@/app/lib/supabase";
+import AnalyticsHeader from "@/app/components/analytics-comp/AnalyticsHeader";
 import PerformanceSummary, {
   type AnalyticsMetric,
   type MemberPerformance,
@@ -41,7 +42,8 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
 
 export default function InsightsAnalyticsPage() {
   const [data, setData] = useState(sprintData);
-  const [sprint, setSprint] = useState("Sprint 42");
+  const [sprintA, setSprintA] = useState("Sprint 42");
+  const [sprintB, setSprintB] = useState("Sprint 41");
   const [metric, setMetric] = useState<AnalyticsMetric>("completed");
   const [selectedMemberId, setSelectedMemberId] = useState("casey");
   const [query, setQuery] = useState("");
@@ -78,7 +80,7 @@ export default function InsightsAnalyticsPage() {
         if (Object.keys(nextData).length > 0) {
           setData(nextData);
           const firstSprint = Object.keys(nextData)[0];
-          setSprint((current) => (nextData[current] ? current : firstSprint));
+          setSprintA((current) => nextData[current] ? current : firstSprint );
           setSelectedMemberId((current) => {
             const activeMembers = nextData[firstSprint] || [];
             return activeMembers.some((member) => member.id === current)
@@ -100,9 +102,35 @@ export default function InsightsAnalyticsPage() {
   }, []);
 
   const members = useMemo(
-    () => data[sprint] || Object.values(data)[0] || [],
-    [data, sprint]
+    () => data[sprintA] || Object.values(data)[0] || [],
+    [data, sprintA]
   );
+  const compareMembers = useMemo(
+  () => data[sprintB] || [],
+  [data, sprintB]
+);
+
+const sprintAMetrics = {
+  completed: members.reduce(
+    (sum, member) => sum + member.completed,
+    0
+  ),
+  reviews: members.reduce(
+    (sum, member) => sum + member.reviews,
+    0
+  ),
+};
+
+const sprintBMetrics = {
+  completed: compareMembers.reduce(
+    (sum, member) => sum + member.completed,
+    0
+  ),
+  reviews: compareMembers.reduce(
+    (sum, member) => sum + member.reviews,
+    0
+  ),
+};
   const selectedMember = members.find((member) => member.id === selectedMemberId) ?? members[0];
 
   const filteredMembers = useMemo(() => {
@@ -117,32 +145,20 @@ export default function InsightsAnalyticsPage() {
 
   return (
   <>
-    <div className="border-b border-outline-variant bg-white px-6 py-4">
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <select
-          value={sprint}
-          onChange={(event) => {
-            const nextSprint = event.target.value;
-            setSprint(nextSprint);
-            setSelectedMemberId(data[nextSprint][0]?.id || "");
-          }}
-          className="rounded-lg border border-outline-variant px-3 py-2"
-        >
-          {Object.keys(data).map((item) => (
-            <option key={item} value={item}>
-              {item}
-            </option>
-          ))}
-        </select>
-
-        <input
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search member, role, or focus..."
-          className="flex-1 rounded-lg border border-outline-variant px-4 py-2"
-        />
-      </div>
-    </div>
+    <AnalyticsHeader
+      sprintA={sprintA}
+      sprintB={sprintB}
+      sprints={Object.keys(data)}
+      query={query}
+      onQueryChange={setQuery}
+      onSprintAChange={(nextSprint) => {
+        setSprintA(nextSprint);
+        setSelectedMemberId(data[nextSprint][0]?.id || "");
+      }}
+      onSprintBChange={(nextSprint) => {
+        setSprintB(nextSprint);
+      }}
+    />
 
     <div className="flex-1 overflow-y-auto w-full custom-scrollbar">
         <div className="p-6 md:p-margin-desktop max-w-container-max mx-auto w-full flex flex-col gap-gutter pb-20 md:pb-8">
@@ -151,6 +167,59 @@ export default function InsightsAnalyticsPage() {
               {isLoading ? "Refreshing analytics from backend..." : loadError}
             </div>
           )}
+          <div className="rounded-2xl border border-outline-variant bg-white p-6">
+  <h3 className="text-lg font-semibold">
+    Sprint Comparison
+  </h3>
+
+  <div className="mt-4 grid gap-4 md:grid-cols-2">
+    <div className="rounded-xl border p-4">
+      <p className="text-sm text-gray-500">
+        Completed Tasks
+      </p>
+
+      <p className="mt-2 text-2xl font-bold">
+        {sprintAMetrics.completed} vs {sprintBMetrics.completed}
+      </p>
+
+      <p
+        className={`mt-1 text-sm ${
+          sprintAMetrics.completed >= sprintBMetrics.completed
+            ? "text-green-600"
+            : "text-red-600"
+        }`}
+      >
+        {sprintAMetrics.completed - sprintBMetrics.completed >= 0
+          ? "+"
+          : ""}
+        {sprintAMetrics.completed - sprintBMetrics.completed}
+      </p>
+    </div>
+
+    <div className="rounded-xl border p-4">
+      <p className="text-sm text-gray-500">
+        Reviews
+      </p>
+
+      <p className="mt-2 text-2xl font-bold">
+        {sprintAMetrics.reviews} vs {sprintBMetrics.reviews}
+      </p>
+
+      <p
+        className={`mt-1 text-sm ${
+          sprintAMetrics.reviews >= sprintBMetrics.reviews
+            ? "text-green-600"
+            : "text-red-600"
+        }`}
+      >
+        {sprintAMetrics.reviews - sprintBMetrics.reviews >= 0
+          ? "+"
+          : ""}
+        {sprintAMetrics.reviews - sprintBMetrics.reviews}
+      </p>
+    </div>
+  </div>
+</div>
           <PerformanceSummary
             members={members}
             metric={metric}
@@ -162,7 +231,7 @@ export default function InsightsAnalyticsPage() {
             onSelectMember={setSelectedMemberId}
           />
           <SprintLeaderboard
-            sprint={sprint}
+            sprint={sprintA}
             members={filteredMembers}
             sortKey={sortKey}
             onSortChange={setSortKey}


### PR DESCRIPTION
## Description

This PR introduces sprint-to-sprint comparison functionality in the Insights → Analytics section.
Previously, analytics data could only be viewed for a single sprint at a time. This enhancement allows users to compare two sprint periods side by side, making it easier to evaluate performance changes across development cycles.

## Changes Made

### Sprint Comparison Support

* Added dual sprint selectors for comparison
* Introduced Sprint A and Sprint B state management
* Enabled dynamic switching between sprint datasets

### Comparison Metrics

Added a new Sprint Comparison section displaying:

* Completed Tasks comparison
* Review Activity comparison
* Difference between selected sprints

### Dynamic Updates

* Metrics update automatically when sprint selections change
* Supports all available sprint datasets
* Preserves existing analytics functionality

## Benefits

* Provides historical sprint context
* Helps teams identify performance improvements or regressions
* Creates a foundation for future analytics enhancements
* Improves visibility into sprint progress over time

## Tech Stack

* Next.js
* React
* TypeScript
* Tailwind CSS

## Screenshot
<img width="1915" height="950" alt="Screenshot from 2026-05-31 12-35-41" src="https://github.com/user-attachments/assets/880234fe-ded2-4c45-ab4b-49657c2c68ef" />


---

## Closes #128
