### PR TITLE
fix(server): restrict Socket.IO CORS to configured frontend origin [NSoC'26]

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -15,8 +15,18 @@ dotenv.config();
 const app = express();
 const server = http.createServer(app);
 
+// Restrict Socket.IO to the known frontend origin.
+// origin: "*" allows any website to open a WebSocket connection, which
+// lets third-party pages subscribe to real-time events or inject messages
+// by abusing a visitor's active session. Reading the origin from the
+// environment keeps the value configurable across deployments.
+const ALLOWED_ORIGIN = process.env.FRONTEND_URL || "http://localhost:5173";
+
 const io = new Server(server, {
-  cors: { origin: "*" },
+  cors: {
+    origin: ALLOWED_ORIGIN,
+    methods: ["GET", "POST"],
+  },
 });
 
 app.set("io", io);


### PR DESCRIPTION
## Description

The Socket.IO server was initialized with `cors: { origin: "*" }`. This allowed any third-party website to open a WebSocket connection to FlowForge from a visitor's browser, subscribe to real-time chat events, join rooms, and inject messages without any origin restriction.

## Related Issue

Closes #136

## Type of Change

- [x] Bug fix (security)

## Root Cause

`origin: "*"` is a wildcard that permits WebSocket upgrade requests from any origin. There was no mechanism to restrict connections to the known frontend URL.

## Changes Made

| File | Change |
|---|---|
| `backend/server.js` | Replaced `cors: { origin: "*" }` with `cors: { origin: ALLOWED_ORIGIN, methods: ["GET", "POST"] }` |
| `backend/server.js` | Added `ALLOWED_ORIGIN` constant read from `process.env.FRONTEND_URL`, defaulting to `http://localhost:5173` |

## Screenshots or Demo

Not applicable (backend-only change).

## Testing Done

- WebSocket connection from `http://localhost:5173` succeeds.
- WebSocket connection from a different origin is rejected with a CORS error.
- Set `FRONTEND_URL=https://your-production-domain.com` in `.env` for production deployments.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] No unnecessary files modified outside the scope of this issue
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## NSoC Label Request

@Shriii19 could you please add the appropriate NSoC '26 label to this PR? It helps with tracking and scoring. Thank you!