### PR TITLE
fix(server): reduce express.json body limit from 50 mb to 512 kb [NSoC'26]

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -30,8 +30,12 @@ const reactionsStore = {};
 
 app.use(cors());
 app.use(apiLimiter);
-app.use(express.json({ limit: "50mb" }));
-app.use(express.urlencoded({ limit: "50mb", extended: true }));
+// Tight body-size limit. Legitimate payloads for this API (task objects,
+// chat messages) are a few kilobytes at most. 50 mb allowed a single
+// request to force the server to allocate and parse 50 MB of JSON before
+// any route handler ran, enabling memory exhaustion with very few requests.
+app.use(express.json({ limit: "512kb" }));
+app.use(express.urlencoded({ limit: "512kb", extended: true }));
 
 app.get("/", (req, res) => {
   res.send("FlowForge Backend Running 🚀");


### PR DESCRIPTION
## Description

The Express body parser was configured with a 50 MB limit. Legitimate payloads for this API (task objects, chat messages) are at most a few kilobytes. The oversized limit allowed a single request to force the server to allocate and parse 50 MB of JSON before any route handler ran. Combined with the existing rate limiter (100 req / 15 min per IP), an attacker could push up to 5 GB of data per window.

## Related Issue

Closes #137

## Type of Change

- [x] Bug fix (security)

## Root Cause

The `limit: "50mb"` value was set on both `express.json()` and `express.urlencoded()`. No legitimate request in the application requires more than a few kilobytes.

## Changes Made

| File | Change |
|---|---|
| `backend/server.js` | Changed `express.json({ limit: "50mb" })` to `express.json({ limit: "512kb" })` |
| `backend/server.js` | Changed `express.urlencoded({ limit: "50mb", ... })` to `express.urlencoded({ limit: "512kb", ... })` |

## Screenshots or Demo

Not applicable (backend-only change).

## Testing Done

- Task creation, chat messages, and all other endpoints work correctly with the new limit.
- A request body larger than 512 KB is rejected by Express with 413 Payload Too Large before reaching any route handler.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] No unnecessary files modified outside the scope of this issue
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## NSoC Label Request

@Shriii19 could you please add the appropriate NSoC '26 label to this PR? Thank you!