### PR TITLE
fix(chat): replace raw Supabase error.message with generic client response [NSoC'26]

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -6,7 +6,10 @@ export const getMessages = async (req, res) => {
     .select("*")
     .order("created_at", { ascending: true });
 
-  if (error) return res.status(500).json({ error: error.message });
+  if (error) {
+    console.error("Supabase error in getMessages:", error);
+    return res.status(500).json({ error: "Failed to retrieve messages." });
+  }
 
   res.json(data);
 };
@@ -32,8 +35,8 @@ export const sendMessage = async (req, res) => {
       .select();
 
     if (error) {
-      console.error("Supabase error:", error);
-      return res.status(500).json({ error: error.message });
+      console.error("Supabase error in sendMessage:", error);
+      return res.status(500).json({ error: "Failed to send message." });
     }
     const io = req.app.get("io");
 


### PR DESCRIPTION
## Description

Both `getMessages` and `sendMessage` in `chat.controller.js` forwarded the raw `error.message` from Supabase directly to HTTP clients. Supabase errors can include PostgreSQL-level details: table names, column names, constraint names, and error codes. Exposing these helps attackers map the database schema for targeted injection or enumeration attacks.

## Related Issue

Closes #138

## Type of Change

- [x] Bug fix (security)

## Root Cause

`res.status(500).json({ error: error.message })` was used in both handlers without any sanitization. The full error object was not logged server-side in either case.

## Changes Made

| File | Change |
|---|---|
| `backend/controllers/chat.controller.js` | `getMessages`: replaced `error.message` with `"Failed to retrieve messages."` and added `console.error` for server-side logging |
| `backend/controllers/chat.controller.js` | `sendMessage`: replaced `error.message` with `"Failed to send message."` and updated the log label |

## Screenshots or Demo

Not applicable (backend-only change).

## Testing Done

- A Supabase error in `getMessages` returns `{ error: "Failed to retrieve messages." }` to the client; the full error appears in server logs.
- A Supabase error in `sendMessage` returns `{ error: "Failed to send message." }` to the client.
- Normal message send and retrieval still work correctly.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] No unnecessary files modified outside the scope of this issue
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## NSoC Label Request

@Shriii19 could you please add the appropriate NSoC '26 label to this PR? Thank you!