### PR TITLE
fix(server): cap reactionsStore at 1000 entries to prevent memory exhaustion [NSoC'26]

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,7 +25,12 @@ const DEFAULT_ROOM = "global-room";
 
 const onlineUsers = new Map();
 
-// store reactions in memory
+// In-memory reactions store, capped to prevent unbounded memory growth.
+// Each unique messageId creates a new entry with no eviction. A user who
+// sends many messages or reacts to many unique IDs would grow this object
+// indefinitely, eventually exhausting process heap. Capping at 1000 entries
+// and evicting the oldest key on overflow keeps memory bounded.
+const MAX_REACTION_ENTRIES = 1000;
 const reactionsStore = {};
 
 app.use(cors());
@@ -66,6 +71,13 @@ io.on("connection", (socket) => {
 
   // REACTIONS
   socket.on("react", ({ messageId, emoji, username }) => {
+    // Evict the oldest tracked message when the cap is reached and this
+    // messageId has not been seen before, keeping the store bounded.
+    if (!reactionsStore[messageId] && Object.keys(reactionsStore).length >= MAX_REACTION_ENTRIES) {
+      const oldestKey = Object.keys(reactionsStore)[0];
+      delete reactionsStore[oldestKey];
+    }
+
     if (!reactionsStore[messageId]) {
       reactionsStore[messageId] = {};
     }


### PR DESCRIPTION
## Description

`reactionsStore` was a plain object with no size cap or eviction policy. Every unique `messageId` added a permanent entry. Over time, as messages accumulated and reactions were added to many distinct message IDs, the store grew without limit. A user who sent many messages or triggered reactions on many unique IDs could exhaust process heap memory.

## Related Issue

Closes #139

## Type of Change

- [x] Bug fix (memory leak)

## Root Cause

`const reactionsStore = {}` had no maximum entry count and no eviction logic. Entries were never deleted, even after their cooldown window long passed.

## Changes Made

| File | Change |
|---|---|
| `backend/server.js` | Added `MAX_REACTION_ENTRIES = 1000` constant with explanatory comment |
| `backend/server.js` | In the `"react"` handler: before inserting a new `messageId`, if the store is at capacity the oldest key is deleted first |

## Screenshots or Demo

Not applicable (backend-only change).

## Testing Done

- After 1000 unique messageIds have reactions, adding a reaction to a new message evicts the oldest entry, keeping `Object.keys(reactionsStore).length` at 1000.
- Reactions on existing message IDs (already in the store) work normally; they do not trigger eviction.
- Toggle behavior (add/remove reaction) is unaffected.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] No unnecessary files modified outside the scope of this issue
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## NSoC Label Request

@Shriii19 could you please add the appropriate NSoC '26 label to this PR? Thank you!