### PR TITLE
feat: add percentage trend indicators for sprint comparison (NSOC'26)

### DIFF
--- a/frontend/app/insights/analytics/page.tsx
+++ b/frontend/app/insights/analytics/page.tsx
@@ -131,6 +131,42 @@ const sprintBMetrics = {
     0
   ),
 };
+const completedDifference =
+  sprintAMetrics.completed -
+  sprintBMetrics.completed;
+
+const reviewsDifference =
+  sprintAMetrics.reviews -
+  sprintBMetrics.reviews;
+
+const completedPercentage =
+  sprintBMetrics.completed === 0
+    ? 0
+    : (completedDifference /
+        sprintBMetrics.completed) *
+      100;
+
+const reviewsPercentage =
+  sprintBMetrics.reviews === 0
+    ? 0
+    : (reviewsDifference /
+        sprintBMetrics.reviews) *
+      100;
+const completedTrend =
+  completedDifference > 0
+    ? "▲"
+    : completedDifference < 0
+    ? "▼"
+    : "●";
+
+const reviewsTrend =
+  reviewsDifference > 0
+    ? "▲"
+    : reviewsDifference < 0
+    ? "▼"
+    : "●";
+
+
   const selectedMember = members.find((member) => member.id === selectedMemberId) ?? members[0];
 
   const filteredMembers = useMemo(() => {
@@ -183,17 +219,20 @@ const sprintBMetrics = {
       </p>
 
       <p
-        className={`mt-1 text-sm ${
-          sprintAMetrics.completed >= sprintBMetrics.completed
-            ? "text-green-600"
-            : "text-red-600"
-        }`}
-      >
-        {sprintAMetrics.completed - sprintBMetrics.completed >= 0
-          ? "+"
-          : ""}
-        {sprintAMetrics.completed - sprintBMetrics.completed}
-      </p>
+  className={`mt-1 text-sm ${
+    completedDifference >= 0
+      ? "text-green-600"
+      : "text-red-600"
+  }`}
+>
+{completedTrend}{" "}
+{completedDifference >= 0 ? "+" : ""}
+{completedDifference}
+{" ("}
+{completedPercentage >= 0 ? "+" : ""}
+{completedPercentage.toFixed(1)}%
+{")"}
+</p>
     </div>
 
     <div className="rounded-xl border p-4">
@@ -206,17 +245,20 @@ const sprintBMetrics = {
       </p>
 
       <p
-        className={`mt-1 text-sm ${
-          sprintAMetrics.reviews >= sprintBMetrics.reviews
-            ? "text-green-600"
-            : "text-red-600"
-        }`}
-      >
-        {sprintAMetrics.reviews - sprintBMetrics.reviews >= 0
-          ? "+"
-          : ""}
-        {sprintAMetrics.reviews - sprintBMetrics.reviews}
-      </p>
+  className={`mt-1 text-sm ${
+    reviewsDifference >= 0
+      ? "text-green-600"
+      : "text-red-600"
+  }`}
+>
+  {reviewsTrend}{" "}
+  {reviewsDifference >= 0 ? "+" : ""}
+  {reviewsDifference}
+  {" ("}
+  {reviewsPercentage >= 0 ? "+" : ""}
+  {reviewsPercentage.toFixed(1)}%
+  {")"}
+</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### NSOC'26

## Summary

Implemented percentage-based trend indicators for Sprint Comparison analytics.

---

### Changes Made

- Added percentage change calculations for:
  - Completed Tasks
  - Reviews

- Added trend indicators:
  - ▲ Positive Growth
  - ▼ Negative Growth
  - ● Neutral Change

- Added color-coded feedback:
  - Green for improvements
  - Red for declines
  
---


### Examples

Before:
Completed Tasks
338 vs 304
+34

After:
Completed Tasks
338 vs 304
▲ +34 (+11.2%)

---


## Screenshots
<img width="1914" height="946" alt="Screenshot from 2026-06-01 00-31-33" src="https://github.com/user-attachments/assets/7bd9f381-8e19-4104-bbfe-1f27d788d3f3" />
<img width="1914" height="946" alt="Screenshot from 2026-06-01 00-31-23" src="https://github.com/user-attachments/assets/1d02f8b9-fbe0-4a96-be0b-2b3506caefb5" />




---

This improves sprint-to-sprint comparison readability and provides better performance context for users.


---


Closes #135