### PR TITLE
fix(tasks): add length validation to updateTask to match createTask limits [NSoC'26]

### DIFF
--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -92,8 +92,28 @@ export const updateTask = async (req, res) => {
     const { title, description, status } = req.body;
     const updateFields = {};
 
-    if (title !== undefined) updateFields.title = title;
-    if (description !== undefined) updateFields.description = description;
+    // Apply the same length limits as createTask so an authenticated user
+    // cannot bypass creation-time validation by patching an existing task.
+    if (title !== undefined) {
+      if (typeof title !== "string" || title.trim().length === 0) {
+        return res.status(400).json({ error: "Task title is required." });
+      }
+      if (title.length > 200) {
+        return res.status(400).json({ error: "Task title must not exceed 200 characters." });
+      }
+      updateFields.title = title;
+    }
+    if (description !== undefined) {
+      if (description !== null) {
+        if (typeof description !== "string") {
+          return res.status(400).json({ error: "Task description must be a string." });
+        }
+        if (description.length > 5000) {
+          return res.status(400).json({ error: "Task description must not exceed 5000 characters." });
+        }
+      }
+      updateFields.description = description;
+    }
 
     // Validate status if provided
     const validStatus = ["todo", "in_progress", "done"];


### PR DESCRIPTION
## Description

`createTask` validated that `title` does not exceed 200 characters and `description` does not exceed 5000 characters. `updateTask` had no corresponding validation, allowing an authenticated user to bypass creation-time limits by sending an oversized payload to `PATCH /tasks/:id/edit`.

## Changes Made

| File | Change |
|---|---|
| `backend/controllers/tasks.controller.js` | Added title non-empty check, 200-character title limit, and 5000-character description limit to `updateTask` |

## Testing Done

- `PATCH /tasks/:id/edit` with `title: "A".repeat(201)` returns 400.
- `PATCH /tasks/:id/edit` with `description: "A".repeat(5001)` returns 400.
- Valid updates proceed normally.

## Checklist

- [x] No merge conflicts with master
- [x] No em dashes or double hyphens in comments
- [x] Changes focused on the reported surface

Closes #162