### PR TITLE
feat: add reusable trend metric card for sprint analytics (NSOC'26)

### DIFF
--- a/frontend/app/components/analytics-comp/TrendMetricCard.tsx
+++ b/frontend/app/components/analytics-comp/TrendMetricCard.tsx
@@ -1,0 +1,54 @@
+type TrendMetricCardProps = {
+  label: string;
+  current: number;
+  previous: number;
+};
+
+export default function TrendMetricCard({
+  label,
+  current,
+  previous,
+}: TrendMetricCardProps) {
+  const difference = current - previous;
+
+  const percentage =
+    previous === 0
+      ? 0
+      : (difference / previous) * 100;
+
+  const trend =
+    difference > 0
+      ? "▲"
+      : difference < 0
+      ? "▼"
+      : "●";
+
+  const colorClass =
+    difference > 0
+      ? "text-green-600"
+      : difference < 0
+      ? "text-red-600"
+      : "text-gray-500";
+
+  return (
+    <div className="rounded-xl border p-4">
+      <p className="text-sm text-gray-500">
+        {label}
+      </p>
+
+      <p className="mt-2 text-2xl font-bold">
+        {current} vs {previous}
+      </p>
+
+      <p className={`mt-1 text-sm ${colorClass}`}>
+        {trend}{" "}
+        {difference > 0 ? "+" : ""}
+        {difference}
+        {" ("}
+        {percentage > 0 ? "+" : ""}
+        {percentage.toFixed(1)}%
+        {")"}
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/insights/analytics/page.tsx
+++ b/frontend/app/insights/analytics/page.tsx
@@ -12,6 +12,7 @@ import SprintLeaderboard, {
   type LeaderboardSortKey,
 } from "@/app/components/analytics-comp/SprintLeaderboard";
 import AnalyticsMobileNav from "@/app/components/analytics-comp/AnalyticsMobileNav";
+import TrendMetricCard from "@/app/components/analytics-comp/TrendMetricCard";
 
 const sprintData: Record<string, MemberPerformance[]> = {
   "Sprint 42": [
@@ -131,40 +132,6 @@ const sprintBMetrics = {
     0
   ),
 };
-const completedDifference =
-  sprintAMetrics.completed -
-  sprintBMetrics.completed;
-
-const reviewsDifference =
-  sprintAMetrics.reviews -
-  sprintBMetrics.reviews;
-
-const completedPercentage =
-  sprintBMetrics.completed === 0
-    ? 0
-    : (completedDifference /
-        sprintBMetrics.completed) *
-      100;
-
-const reviewsPercentage =
-  sprintBMetrics.reviews === 0
-    ? 0
-    : (reviewsDifference /
-        sprintBMetrics.reviews) *
-      100;
-const completedTrend =
-  completedDifference > 0
-    ? "▲"
-    : completedDifference < 0
-    ? "▼"
-    : "●";
-
-const reviewsTrend =
-  reviewsDifference > 0
-    ? "▲"
-    : reviewsDifference < 0
-    ? "▼"
-    : "●";
 
 
   const selectedMember = members.find((member) => member.id === selectedMemberId) ?? members[0];
@@ -209,57 +176,19 @@ const reviewsTrend =
   </h3>
 
   <div className="mt-4 grid gap-4 md:grid-cols-2">
-    <div className="rounded-xl border p-4">
-      <p className="text-sm text-gray-500">
-        Completed Tasks
-      </p>
+    <TrendMetricCard
+  label="Completed Tasks"
+  current={sprintAMetrics.completed}
+  previous={sprintBMetrics.completed}
+/>
 
-      <p className="mt-2 text-2xl font-bold">
-        {sprintAMetrics.completed} vs {sprintBMetrics.completed}
-      </p>
+<TrendMetricCard
+  label="Reviews"
+  current={sprintAMetrics.reviews}
+  previous={sprintBMetrics.reviews}
+/>
 
-      <p
-  className={`mt-1 text-sm ${
-    completedDifference >= 0
-      ? "text-green-600"
-      : "text-red-600"
-  }`}
->
-{completedTrend}{" "}
-{completedDifference >= 0 ? "+" : ""}
-{completedDifference}
-{" ("}
-{completedPercentage >= 0 ? "+" : ""}
-{completedPercentage.toFixed(1)}%
-{")"}
-</p>
-    </div>
-
-    <div className="rounded-xl border p-4">
-      <p className="text-sm text-gray-500">
-        Reviews
-      </p>
-
-      <p className="mt-2 text-2xl font-bold">
-        {sprintAMetrics.reviews} vs {sprintBMetrics.reviews}
-      </p>
-
-      <p
-  className={`mt-1 text-sm ${
-    reviewsDifference >= 0
-      ? "text-green-600"
-      : "text-red-600"
-  }`}
->
-  {reviewsTrend}{" "}
-  {reviewsDifference >= 0 ? "+" : ""}
-  {reviewsDifference}
-  {" ("}
-  {reviewsPercentage >= 0 ? "+" : ""}
-  {reviewsPercentage.toFixed(1)}%
-  {")"}
-</p>
-    </div>
+    
   </div>
 </div>
           <PerformanceSummary


### PR DESCRIPTION
### NSOC'26

## Description

This PR refactors the Sprint Comparison section by introducing a reusable TrendMetricCard component.

## Changes Made

### Reusable Component

- Added `TrendMetricCard.tsx`
- Encapsulated trend calculation logic
- Centralized difference and percentage calculations

### Trend Logic Refactor

Moved the following logic into the component:

- Difference calculation
- Percentage calculation
- Trend indicator selection
- Color state handling

### Neutral State Support

Added a dedicated neutral trend state:

- ● 0 (0.0%)

Displayed using a neutral gray color instead of positive styling.

### Code Cleanup

- Removed duplicated trend logic
- Replaced existing comparison cards with reusable component instances
- Improved maintainability and future scalability

### Screenshot
<img width="1920" height="961" alt="Screenshot from 2026-06-03 09-05-20" src="https://github.com/user-attachments/assets/3b5de48a-5948-4bbd-b3cf-1e64f9036e92" />


## Tech Stack

- Next.js
- React
- TypeScript
- Tailwind CSS