### PR TITLE
feat: add centralized toast queue management

### DIFF
--- a/frontend/app/context/ToastContext.tsx
+++ b/frontend/app/context/ToastContext.tsx
@@ -17,7 +17,7 @@ interface ToastContextValue {
 const ToastContext = createContext<ToastContextValue>({
   showToast: () => {},
 });
-
+const MAX_TOASTS = 4;
 export function useToast() {
   return useContext(ToastContext);
 }
@@ -25,13 +25,41 @@ export function useToast() {
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = useCallback((message: string, type: ToastType = "info") => {
-    const id = Date.now();
-    setToasts((prev) => [...prev, { id, message, type }]);
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id));
-    }, 4000);
-  }, []);
+  const showToast = useCallback(
+    (message: string, type: ToastType = "info") => {
+      const id = Date.now();
+
+      setToasts((prev) => {
+        const duplicateExists = prev.some(
+          (toast) =>
+            toast.message === message &&
+            toast.type === type
+        );
+
+        if (duplicateExists) {
+          return prev;
+        }
+
+        const updated = [
+          ...prev,
+          { id, message, type },
+        ];
+
+        if (updated.length > MAX_TOASTS) {
+          updated.shift();
+        }
+
+        return updated;
+      });
+
+      setTimeout(() => {
+        setToasts((prev) =>
+          prev.filter((t) => t.id !== id)
+        );
+      }, 4000);
+    },
+    []
+  );
 
   const removeToast = (id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));


### PR DESCRIPTION
## 📝 Description

This PR improves the toast notification system by introducing centralized queue management and controlled stacking behavior.

### Changes Made
- Added centralized toast queue handling inside `ToastContext`
- Introduced a maximum toast stack limit to prevent notification overflow
- Prevented duplicate toast notifications from being rendered simultaneously
- Improved toast lifecycle management during high-frequency notification bursts
- Maintained existing auto-dismiss and manual dismissal functionality

### Benefits
- Reduces visual clutter caused by excessive notifications
- Prevents duplicate toast rendering
- Improves notification consistency and user experience
- Ensures predictable toast stacking behavior
- Provides cleaner handling of rapid successive notifications

### Testing
- Verified duplicate notifications are ignored
- Verified toast stack remains within the configured limit
- Verified auto-dismiss behavior still functions correctly
- Verified manual dismissal still removes notifications as expected

Fixes #157

### Expected Labels
`level3` `NSoC'26`