### PR TITLE
fix: improve realtime kanban synchronization

### DIFF
--- a/frontend/app/components/kanban/KanbanBoard.tsx
+++ b/frontend/app/components/kanban/KanbanBoard.tsx
@@ -46,6 +46,7 @@ export function KanbanBoard() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const socketRef = useRef<ReturnType<typeof io> | null>(null);
+  const isSyncingRef = useRef(false);
 
   const handleEditTask = async (task: Task) => {
   const newTitle = window.prompt("Edit title:", task.title);
@@ -105,7 +106,8 @@ export function KanbanBoard() {
       void fetchTasks();
     }, 0);
 
-    newSocket.on("task-moved", (movedTask: Task) => {
+      newSocket.on("task-moved", (movedTask: Task) => {
+        if (isSyncingRef.current) return;
       setTasks((prev) => {
         const existing = prev.find((t) => t.id === movedTask.id);
         let newTasks;
@@ -155,8 +157,9 @@ export function KanbanBoard() {
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { active, over } = event;
-    if (!over) return;
+  const { active, over } = event;
+
+  if (!over) return;
 
     const activeId = active.id;
     const overId = over.id;
@@ -198,21 +201,33 @@ export function KanbanBoard() {
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
-  setActiveTask(null);
+    if (isSyncingRef.current) return;
+
+    isSyncingRef.current = true;
+    setActiveTask(null);
 
   const { active, over } = event;
-  if (!over) return;
+  if (!over) {
+    isSyncingRef.current = false;
+    return;
+  }
 
   const activeId = active.id;
   const overId = over.id;
 
   const activeTask = tasks.find((t) => t.id === activeId);
-  if (!activeTask) return;
+  if (!activeTask) {
+    isSyncingRef.current = false;
+    return;
+  }
 
   let newStatus = activeTask.status;
 
   if (over.data.current?.type === "Column") {
-    if (!isTaskStatus(over.id)) return;
+    if (!isTaskStatus(over.id)) {
+      isSyncingRef.current = false;
+      return;
+    }
     newStatus = over.id;
   } else if (over.data.current?.type === "Task") {
     const overTask = tasks.find((t) => t.id === overId);
@@ -283,10 +298,13 @@ export function KanbanBoard() {
           task,
         });
       });
+
     }
   } catch (error) {
     console.error("Failed to update task positions", error);
+    isSyncingRef.current = false;
   }
+  isSyncingRef.current = false;
 };
 
     


### PR DESCRIPTION
## 📝 Description

This PR improves Kanban drag-and-drop synchronization reliability by introducing safeguards against concurrent synchronization operations and reducing potential race conditions between optimistic UI updates and realtime socket events.

### Changes Made
- Added synchronization locking during drag-and-drop update operations
- Prevented concurrent drag synchronization requests from executing simultaneously
- Ignored incoming realtime task movement events while local synchronization is in progress
- Improved reconciliation between optimistic frontend updates and socket-based updates
- Added safer synchronization state handling during drag completion and error scenarios

### Benefits
- Reduces temporary ordering inconsistencies during rapid task movements
- Minimizes realtime overwrite conflicts between clients
- Improves task position synchronization reliability
- Prevents race-condition-driven UI drift
- Creates more stable collaborative Kanban interactions

### Testing
- Verified task reordering continues to function correctly
- Verified realtime task movement updates are received successfully
- Verified synchronization lock is released after successful updates
- Verified synchronization lock is released during error scenarios
- Tested consecutive drag-and-drop operations for stable behavior

Fixes #156 

### Expected Labels
`level3` `NSoC'26`