### PR TITLE
feat: add deterministic tie-breaking for sprint leaderboard rankings

### DIFF
--- a/frontend/app/components/analytics-comp/SprintLeaderboard.tsx
+++ b/frontend/app/components/analytics-comp/SprintLeaderboard.tsx
@@ -16,6 +16,59 @@ function impactScore(member: MemberPerformance) {
   return Number((member.completed * 0.8 + member.reviews * 1.6).toFixed(1));
 }
 
+type RankedMember = MemberPerformance & {
+  rank: number;
+  score: number;
+};
+
+function compareMembers(
+  a: MemberPerformance,
+  b: MemberPerformance,
+  sortKey: LeaderboardSortKey
+) {
+  if (sortKey === "score") {
+    const scoreDifference =
+      impactScore(b) - impactScore(a);
+
+    if (scoreDifference !== 0) {
+      return scoreDifference;
+    }
+  } else {
+    const metricDifference =
+      b[sortKey] - a[sortKey];
+
+    if (metricDifference !== 0) {
+      return metricDifference;
+    }
+  }
+
+  if (b.completed !== a.completed) {
+    return b.completed - a.completed;
+  }
+
+  if (b.reviews !== a.reviews) {
+    return b.reviews - a.reviews;
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+function buildRankedLeaderboard(
+  members: MemberPerformance[],
+  sortKey: LeaderboardSortKey
+): RankedMember[] {
+  const sortedMembers = [...members].sort(
+    (a, b) => compareMembers(a, b, sortKey)
+  );
+
+  return sortedMembers.map((member, index) => ({
+    ...member,
+    rank: index + 1,
+    score: impactScore(member),
+  }));
+}
+
+
 export default function SprintLeaderboard({
   sprint,
   members,
@@ -23,10 +76,10 @@ export default function SprintLeaderboard({
   onSortChange,
 }: SprintLeaderboardProps) {
   const sortedRows = useMemo(() => {
-    return [...members].sort((a, b) => {
-      if (sortKey === "score") return impactScore(b) - impactScore(a);
-      return b[sortKey] - a[sortKey];
-    });
+    return buildRankedLeaderboard(
+      members,
+      sortKey
+    );
   }, [members, sortKey]);
 
   return (
@@ -78,7 +131,7 @@ export default function SprintLeaderboard({
               {sortedRows.map((row, index) => (
                 <tr key={row.id} className="border-b border-outline-variant/50 hover:bg-surface-container-low transition-colors">
                   <td className="px-card-padding py-4 font-bold text-primary">
-                    {(index + 1).toString().padStart(2, "0")}
+                    {row.rank.toString().padStart(2, "0")}
                   </td>
                   <td className="px-card-padding py-4">
                     <div className="flex items-center gap-3">
@@ -91,7 +144,7 @@ export default function SprintLeaderboard({
                   </td>
                   <td className="px-card-padding py-4 font-data-viz">{row.completed}</td>
                   <td className="px-card-padding py-4 font-data-viz">{row.reviews}</td>
-                  <td className="px-card-padding py-4 text-right font-bold text-primary">{impactScore(row)}</td>
+                  <td className="px-card-padding py-4 text-right font-bold text-primary">{row.score}</td>
                 </tr>
               ))}
               {sortedRows.length === 0 && (


### PR DESCRIPTION
## 🔗 Related Issue

Fixes #325 

## 📝 Description

This PR improves the stability and transparency of leaderboard rankings by introducing deterministic tie-breaking rules for members with identical primary metrics.

Previously, leaderboard ordering relied solely on the selected sort metric, which could result in inconsistent ranking outcomes when multiple members shared the same values. This made ranking behavior difficult to audit and could lead to unexpected ordering changes across renders.

The updated implementation introduces a dedicated ranking pipeline that applies consistent tie-breaking criteria and generates explicit leaderboard rankings.

## 🔧 Changes Made

- Added a dedicated leaderboard ranking utility.
- Implemented deterministic tie-breaking logic for equal metric values.
- Introduced secondary and tertiary ranking criteria using completed work and peer reviews.
- Added alphabetical ordering as the final fallback to ensure stable results.
- Added explicit rank generation for leaderboard entries.
- Precomputed impact scores during leaderboard construction.
- Refactored sorting logic into reusable helper functions for improved maintainability.

## ✅ Benefits

- Ensures predictable leaderboard ordering.
- Improves fairness when participants have similar performance metrics.
- Makes ranking outcomes easier to audit and explain.
- Prevents unstable ordering across renders.
- Improves maintainability of leaderboard ranking logic.

## 🧪 Testing

- Verified sorting by impact score.
- Verified sorting by completed stories.
- Verified sorting by peer reviews.
- Tested multiple members with identical metric values.
- Confirmed deterministic ordering across repeated renders.
- Confirmed generated ranks remain consistent after sorting changes.

## Expected Labels
`level3` `NSoC'26`