### PR TITLE
feat: add leaderboard rank badges and top contributor highlights (NSOC'26)

### DIFF
--- a/frontend/app/components/analytics-comp/SprintLeaderboard.tsx
+++ b/frontend/app/components/analytics-comp/SprintLeaderboard.tsx
@@ -24,18 +24,16 @@ type RankedMember = MemberPerformance & {
 function compareMembers(
   a: MemberPerformance,
   b: MemberPerformance,
-  sortKey: LeaderboardSortKey
+  sortKey: LeaderboardSortKey,
 ) {
   if (sortKey === "score") {
-    const scoreDifference =
-      impactScore(b) - impactScore(a);
+    const scoreDifference = impactScore(b) - impactScore(a);
 
     if (scoreDifference !== 0) {
       return scoreDifference;
     }
   } else {
-    const metricDifference =
-      b[sortKey] - a[sortKey];
+    const metricDifference = b[sortKey] - a[sortKey];
 
     if (metricDifference !== 0) {
       return metricDifference;
@@ -55,10 +53,10 @@ function compareMembers(
 
 function buildRankedLeaderboard(
   members: MemberPerformance[],
-  sortKey: LeaderboardSortKey
+  sortKey: LeaderboardSortKey,
 ): RankedMember[] {
-  const sortedMembers = [...members].sort(
-    (a, b) => compareMembers(a, b, sortKey)
+  const sortedMembers = [...members].sort((a, b) =>
+    compareMembers(a, b, sortKey),
   );
 
   return sortedMembers.map((member, index) => ({
@@ -68,7 +66,6 @@ function buildRankedLeaderboard(
   }));
 }
 
-
 export default function SprintLeaderboard({
   sprint,
   members,
@@ -76,10 +73,7 @@ export default function SprintLeaderboard({
   onSortChange,
 }: SprintLeaderboardProps) {
   const sortedRows = useMemo(() => {
-    return buildRankedLeaderboard(
-      members,
-      sortKey
-    );
+    return buildRankedLeaderboard(members, sortKey);
   }, [members, sortKey]);
 
   return (
@@ -124,32 +118,67 @@ export default function SprintLeaderboard({
                 <th className="px-card-padding py-4">Member</th>
                 <th className="px-card-padding py-4">Stories Resolved</th>
                 <th className="px-card-padding py-4">Peer Reviews</th>
-                <th className="px-card-padding py-4 text-right">Impact Score</th>
+                <th className="px-card-padding py-4 text-right">
+                  Impact Score
+                </th>
               </tr>
             </thead>
             <tbody className="font-body-md">
               {sortedRows.map((row, index) => (
-                <tr key={row.id} className="border-b border-outline-variant/50 hover:bg-surface-container-low transition-colors">
+                <tr
+                  key={row.id}
+                  className={`border-b border-outline-variant/50 transition-colors hover:bg-surface-container-low
+    ${
+      row.rank === 1
+        ? "bg-yellow-50"
+        : row.rank === 2
+          ? "bg-gray-50"
+          : row.rank === 3
+            ? "bg-orange-50"
+            : ""
+    }`}
+                >
                   <td className="px-card-padding py-4 font-bold text-primary">
-                    {row.rank.toString().padStart(2, "0")}
+                    {row.rank === 1
+                      ? "🥇"
+                      : row.rank === 2
+                        ? "🥈"
+                        : row.rank === 3
+                          ? "🥉"
+                          : row.rank.toString().padStart(2, "0")}
                   </td>
                   <td className="px-card-padding py-4">
                     <div className="flex items-center gap-3">
-                      <img alt={row.name} className="w-8 h-8 rounded-full" src={row.image} />
+                      <img
+                        alt={row.name}
+                        className="w-8 h-8 rounded-full"
+                        src={row.image}
+                      />
                       <div>
                         <span>{row.name}</span>
-                        <p className="text-xs text-on-surface-variant">{row.focus}</p>
+                        <p className="text-xs text-on-surface-variant">
+                          {row.focus}
+                        </p>
                       </div>
                     </div>
                   </td>
-                  <td className="px-card-padding py-4 font-data-viz">{row.completed}</td>
-                  <td className="px-card-padding py-4 font-data-viz">{row.reviews}</td>
-                  <td className="px-card-padding py-4 text-right font-bold text-primary">{row.score}</td>
+                  <td className="px-card-padding py-4 font-data-viz">
+                    {row.completed}
+                  </td>
+                  <td className="px-card-padding py-4 font-data-viz">
+                    {row.reviews}
+                  </td>
+                  <td className="px-card-padding py-4 text-right font-bold text-primary">
+                    {row.score}
+                  </td>
                 </tr>
               ))}
               {sortedRows.length === 0 && (
                 <tr>
-                  <td className="px-card-padding py-8 text-center text-on-surface-variant" colSpan={5}>
+                  <td
+                    className="px-card-padding py-8 text-center text-on-surface-variant"
+                    colSpan={5}
+                  >
                     No members match the current search.
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary

This PR enhances the Sprint Participation Leaderboard by improving ranking visibility and contributor recognition.

### Changes Made

* Added medal badges for the top three contributors:

  * 🥇 Rank 1
  * 🥈 Rank 2
  * 🥉 Rank 3

* Added visual row highlights for top-ranked contributors:

  * Gold highlight for first place
  * Silver highlight for second place
  * Bronze highlight for third place

* Preserved existing leaderboard sorting functionality:

  * Impact Score
  * Completed Work
  * Peer Reviews

### Benefits

* Improves leaderboard readability
* Makes top performers easier to identify
* Provides a more engaging analytics experience
* Enhances contributor recognition within sprint analytics

### Screenshots

Added updated leaderboard UI showing medal badges and highlighted top contributor rows.

---

<img width="1916" height="677" alt="Screenshot from 2026-06-15 20-08-10" src="https://github.com/user-attachments/assets/68909789-9d2e-40ce-8bc4-fedaacd2ad18" />

---

## Closes #252