### PR TITLE
fix: Auto-fill chat username from Supabase session instead of manual entry

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -184,6 +184,22 @@ export default function ChatPage() {
     setSessionRecovered,
   ] = useState(false);
 
+  // Auto-fill username from Supabase session
+  useEffect(() => {
+    const getUsername = async () => {
+      if (!supabase) return;
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.user) {
+        const name =
+          session.user.user_metadata?.full_name ||
+          session.user.email?.split("@")[0] ||
+          "User";
+        setUsername(name);
+      }
+    };
+    getUsername();
+  }, []);
+
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
 


### PR DESCRIPTION
## Summary
Fixed the Chat page which required users to 
manually type their name before chatting, even 
though they were already authenticated via Supabase.

## Root Cause
In `frontend/app/chat/page.tsx`:
```tsx
const [username, setUsername] = useState("");
```
Username was initialized as empty string with 
no connection to the authenticated user session.

## Fix
Added a `useEffect` that fetches the real 
username from Supabase session on mount:

```tsx
useEffect(() => {
  const getUsername = async () => {
    if (!supabase) return;
    const { data: { session } } = 
      await supabase.auth.getSession();
    if (session?.user) {
      const name =
        session.user.user_metadata?.full_name ||
        session.user.email?.split("@")[0] ||
        "User";
      setUsername(name);
    }
  };
  getUsername();
}, []);
```

Priority order for username:
1. `user_metadata.full_name` (real name)
2. Email prefix before `@` (fallback)
3. "User" (final fallback)

## Before
- Username input was empty on page load
- User had to manually type their name
- Messages could appear under wrong identity

## After
- ✅ Username auto-filled from Supabase session
- ✅ User can start chatting immediately
- ✅ Username input still editable if needed

## Screenshots
<img width="1920" height="961" alt="image" src="https://github.com/user-attachments/assets/e6dc8ce6-8967-4d9b-adb7-154638ce9bec" />


## Files Changed
- `frontend/app/chat/page.tsx` — only file modified

## Issue
Closes #255

nsoc26